### PR TITLE
Arm64 Support For Travis-Ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: xenial
+dist: bionic
 
 addons:
   artifacts:
@@ -10,6 +10,9 @@ addons:
 branches:
   only:
     - master
+    - 3.10.x
+    - 3.12.x
+
 env:
   global:
     - CI_NODE_TOTAL=6
@@ -32,7 +35,9 @@ matrix:
     - os: linux
       env: JOB_TYPE=compile_and_unit_test COVERAGE=no
       compiler: clang
-   
+    - os: osx
+      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
+      sudo: false
     - arch: arm64
       os: linux
       env: JOB_TYPE=compile_and_unit_test_asan
@@ -43,12 +48,11 @@ matrix:
       os: linux
       env: JOB_TYPE=compile_and_unit_test COVERAGE=no
       compiler: clang
-    - os: osx
-      env: JOB_TYPE=compile_and_unit_test COVERAGE=no
-      sudo: false
 
 before_install:
-  - sudo apt-get install -y libpcre3 libpcre3-dev
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+        sudo apt-get install -y libpcre3 libpcre3-dev;
+    fi
   - chmod ug+x ./travis-scripts/*
   - ./travis-scripts/before_install.sh
 

--- a/libutils/buffer.c
+++ b/libutils/buffer.c
@@ -111,7 +111,12 @@ int BufferCompare(const Buffer *buffer1, const Buffer *buffer2)
             /*
              * C String comparison
              */
-            return strcmp(buffer1->buffer, buffer2->buffer);
+            // Adding this as strcmp gives difference of the buffer values at aarch64 whereas it gives 1 or -1 in other platforms, in case compared char buffer were not same.
+            int compare_result = strcmp(buffer1->buffer, buffer2->buffer);
+#ifdef __aarch64__
+            compare_result = compare_result / abs(compare_result);
+#endif
+            return compare_result;
         }
         else
         {

--- a/libutils/string_lib.c
+++ b/libutils/string_lib.c
@@ -62,7 +62,7 @@ size_t StringCopy(const char *const from, char *const to, const size_t buf_size)
     assert(from != NULL);
     assert(to != NULL);
     assert(from != to);
-    assert(buf_size >= 0);
+    assert((signed)buf_size >= 0);
 
     memset(to, 0, buf_size);
     strncpy(to, from, buf_size);
@@ -231,7 +231,12 @@ int StringSafeCompare(const char *const a, const char *const b)
     }
     if (a != NULL && b != NULL)
     {
-        return strcmp(a, b);
+        // Adding this as strcmp gives difference of the buffer values at aarch64 whereas it gives 1 or -1 in other platforms, in case compared char buffer were not same.
+        int compare_result = strcmp(a, b);
+#ifdef __aarch64__
+        compare_result = compare_result / abs(compare_result);
+#endif
+        return compare_result;
     }
 
     // Weird edge cases where one is NULL:


### PR DESCRIPTION
Hi,

Package Owner: Mohneesh Jha
PR change Details:

#Patch Details : .travis.yml, libutils/buffer.c and libutils/string_lib.c have been modified :
.travis.yml : Arm64 jobs has been added with the installation of package require for arm64
libutils/buffer.c: Strcmp() workaround is done for arm64.
libutils/string_lib.c: Strcmp() workaround is done for arm64 and typecasting of char to signed is done as by default arm takes char as unsigned char
#Testing Detail :
The testing is done over travis

#Reviewer Comment : < To be filled by Reviewer >

#PR Description :
Here is my commit message :
Adding Arm64-Support in travis.
Workaround is done for libutils/buffer.c and libutils/string_lib.c for strcmp() function as strcmp() has different behaviour in arm64 and amd64. In Arm64, strcmp(char* a,char* b) gives the value of -64 instead of -1.
In line 65 of libutils/string_lib.c typecasting is done as some architecture consider char as unsigned char and some consider it as signed char such as amd64 consider default char as signed char whereas arm64 consider it as unsigned char.

Body of PR :
Added ARM64 job in Travis-CI .

.travis.yml : Arm64 jobs has been added with the installation of package require for arm64
libutils/buffer.c: Strcmp() workaround is done for arm64.
libutils/string_lib.c: Strcmp() workaround is done for arm64 and typecasting of char to signed is done as by default arm takes char as unsigned char
.
Signed-off-by: odidev@puresoftware.com.
#Reviewer: Pruthvi Teja and Shobhit Prasari

Thanks,
Mohneesh Jha